### PR TITLE
Add Runpod environment guard, lazy-load modules, docs and version bump to 0.6.4

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.md
 include LICENSE
-exclude CLAUDE.md

--- a/OhMyRunpod/environment.py
+++ b/OhMyRunpod/environment.py
@@ -1,0 +1,41 @@
+"""Environment checks for Runpod-specific execution."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+
+RUNPOD_ENV_VARS = (
+    "RUNPOD_POD_ID",
+    "RUNPOD_PUBLIC_IP",
+    "RUNPOD_TCP_PORT_22",
+    "RUNPOD_DC_ID",
+)
+
+LOCAL_INSTALL_OVERRIDE = "OHMYRUNPOD_ALLOW_LOCAL_INSTALL"
+
+
+def is_runpod_environment(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """Return True when the current process appears to be running on Runpod."""
+    env = environ if environ is not None else os.environ
+    return any(env.get(var) for var in RUNPOD_ENV_VARS)
+
+
+def local_install_override_enabled(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """Return True when local installation/execution was explicitly allowed."""
+    env = environ if environ is not None else os.environ
+    return env.get(LOCAL_INSTALL_OVERRIDE, "").lower() in {"1", "true", "yes", "on"}
+
+
+def should_block_outside_runpod(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """Return True when OhMyRunpod should refuse to run or install."""
+    return not is_runpod_environment(environ) and not local_install_override_enabled(environ)
+
+
+def outside_runpod_message(action: str = "run") -> str:
+    """Build a clear error message for users outside Runpod."""
+    return (
+        f"OhMyRunpod is intended to {action} only inside Runpod pods. "
+        "If you are developing or testing locally, set "
+        f"{LOCAL_INSTALL_OVERRIDE}=1 to bypass this guard."
+    )

--- a/OhMyRunpod/main.py
+++ b/OhMyRunpod/main.py
@@ -1,14 +1,25 @@
 import argparse
 import os
 import sys
-from OhMyRunpod.modules.ssh_setup.ssh_setup import run_ssh_setup_script
-from OhMyRunpod.modules.pod_info import print_pod_info
-from OhMyRunpod.modules.file_transfer import show_file_transfer_menu
-from OhMyRunpod.modules.comfyui import show_comfyui_menu
-from OhMyRunpod.ui import InteractiveMenu
-from rich.console import Console
 
-console = Console()
+from OhMyRunpod.environment import outside_runpod_message, should_block_outside_runpod
+
+console = None
+
+
+def load_runpod_modules():
+    """Load dependencies only after the Runpod environment guard passes."""
+    global Console, InteractiveMenu, console
+    global run_ssh_setup_script, print_pod_info, show_file_transfer_menu, show_comfyui_menu
+
+    from rich.console import Console
+    from OhMyRunpod.modules.ssh_setup.ssh_setup import run_ssh_setup_script
+    from OhMyRunpod.modules.pod_info import print_pod_info
+    from OhMyRunpod.modules.file_transfer import show_file_transfer_menu
+    from OhMyRunpod.modules.comfyui import show_comfyui_menu
+    from OhMyRunpod.ui import InteractiveMenu
+
+    console = Console()
 
 def run_interactive_mode():
     """Run the interactive menu mode"""
@@ -59,6 +70,12 @@ def run_interactive_mode():
             input()
 
 def main():
+    if should_block_outside_runpod():
+        print(outside_runpod_message())
+        sys.exit(1)
+
+    load_runpod_modules()
+
     parser = argparse.ArgumentParser(description="OhMyRunpod Command Line Tool")
     parser.add_argument('--setup-ssh', action='store_true', help='Run the SSH setup script')
     parser.add_argument('--info', action='store_true', help='Display information about the Pod')

--- a/OhMyRunpod/ui.py
+++ b/OhMyRunpod/ui.py
@@ -8,7 +8,7 @@ class InteractiveMenu:
         self.console = Console()
         self.options = [
             ("SSH Setup", "Configure SSH server and create connection scripts"),
-            ("Pod Information", "Display RunPod environment information"),
+            ("Pod Information", "Display Runpod environment information"),
             ("File Transfer", "Setup file transfer with croc or SFTP"),
             ("ComfyUI", "Install and manage ComfyUI"),
             ("Exit", "Exit the application"),
@@ -17,7 +17,7 @@ class InteractiveMenu:
     def run(self) -> int:
         menu = BaseMenu(
             title="OhMyRunpod",
-            subtitle="RunPod Environment Management Tool",
+            subtitle="Runpod Environment Management Tool",
             options=self.options,
             breadcrumbs=["Home"],
             help_lines=[

--- a/README.md
+++ b/README.md
@@ -17,10 +17,19 @@ OhMyRunpod is a comprehensive command-line tool designed to facilitate various o
 
 ## Installation
 
-To install OhMyRunpod, you can use pip:
+OhMyRunpod is intended to run inside Runpod pods only. The command checks for Runpod-provided environment variables at startup so users do not accidentally use it on a personal machine.
+
+To install OhMyRunpod on a Runpod pod, you can use pip:
 
 ```bash
 pip install OhMyRunpod
+```
+
+For local development or CI outside Runpod, install normally and explicitly opt in when running the command:
+
+```bash
+pip install -e .
+OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1 OhMyRunpod --info
 ```
 
 ## Usage
@@ -77,7 +86,7 @@ OhMyRunpod provides comprehensive ComfyUI management through integration with [c
 ## Requirements
 
 - Python 3.7+
-- Linux environment (designed for RunPod)
+- Linux environment (designed for Runpod)
 - Rich library for terminal UI (automatically installed)
 
 ## Contributing

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8'
 
 setup(
     name='OhMyRunpod',
-    version='0.6.3',
+    version='0.6.4',
     author='Madiator2011',
     author_email='admin@madiator.com',
+    license='GPL-3.0-or-later',
     url='https://github.com/kodxana/OhMyRunpod-python',
     packages=find_packages(),
     include_package_data=True,
@@ -18,8 +19,8 @@ setup(
         'rich>=13.0.0',
     ],
     project_urls={
-        'Source': 'https://github.com/kodxana/OhMyRunPod-python',
-        'Bug Reports': 'https://github.com/kodxana/OhMyRunPod-python/issues',
+        'Source': 'https://github.com/kodxana/OhMyRunpod-python',
+        'Bug Reports': 'https://github.com/kodxana/OhMyRunpod-python/issues',
     },
     entry_points={
         'console_scripts': [
@@ -29,7 +30,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
### Motivation

- Prevent accidental use or installation of OhMyRunpod on non-Runpod machines by detecting Runpod environment variables and requiring an explicit opt-in for local installs. 
- Avoid importing UI and Runpod-specific modules before verifying the runtime environment to reduce startup errors and unnecessary imports. 
- Correct branding/casing and update packaging metadata for the new release.

### Description

- Add `OhMyRunpod/environment.py` with `is_runpod_environment`, `local_install_override_enabled`, `should_block_outside_runpod`, and `outside_runpod_message` functions to encapsulate environment detection and an explicit local-install override (`OHMYRUNPOD_ALLOW_LOCAL_INSTALL`).
- Update `OhMyRunpod/main.py` to check `should_block_outside_runpod()` at startup, print the `outside_runpod_message()` and exit when appropriate, and introduce `load_runpod_modules()` to lazily import `rich`, `InteractiveMenu`, and module handlers only after the guard passes.
- Adjust `OhMyRunpod/ui.py` copy to use consistent "Runpod" casing in menu texts and subtitles.
- Update `README.md` to document the Runpod-only guard and show how to opt in for local development using `OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1`.
- Bump package version to `0.6.4` in `setup.py`, add `license='GPL-3.0-or-later'`, fix project URL entries, and tidy classifiers.
- Remove the `exclude CLAUDE.md` line from `MANIFEST.in`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a6d3d18e48327aa3dd8d05ee7b567)