### PR TITLE
Allow package builds/CI outside Runpod; add SPDX license metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OhMyRunpod is a comprehensive command-line tool designed to facilitate various o
 
 ## Installation
 
-OhMyRunpod is intended to be installed and run inside Runpod pods only. The package checks for Runpod-provided environment variables during installation and startup so users do not accidentally install it on a personal machine.
+OhMyRunpod is intended to run inside Runpod pods only. The command checks for Runpod-provided environment variables at startup so users do not accidentally run it on a personal machine, while package builds and CI can still create source and wheel distributions.
 
 To install OhMyRunpod on a Runpod pod, you can use pip:
 
@@ -25,10 +25,10 @@ To install OhMyRunpod on a Runpod pod, you can use pip:
 pip install OhMyRunpod
 ```
 
-For local development or CI outside Runpod, explicitly opt in to bypass the guard:
+For local development outside Runpod, installation and package builds work normally. Explicitly opt in only when you need to run the command locally:
 
 ```bash
-OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1 pip install -e .
+pip install -e .
 OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1 OhMyRunpod --info
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,5 @@
 from setuptools import setup, find_packages
 import os
-import sys
-
-RUNPOD_ENV_VARS = (
-    'RUNPOD_POD_ID',
-    'RUNPOD_PUBLIC_IP',
-    'RUNPOD_TCP_PORT_22',
-    'RUNPOD_DC_ID',
-)
-LOCAL_INSTALL_OVERRIDE = 'OHMYRUNPOD_ALLOW_LOCAL_INSTALL'
-
-def is_runpod_environment():
-    return any(os.environ.get(var) for var in RUNPOD_ENV_VARS)
-
-def local_install_override_enabled():
-    return os.environ.get(LOCAL_INSTALL_OVERRIDE, '').lower() in {'1', 'true', 'yes', 'on'}
-
-if 'egg_info' not in sys.argv and not is_runpod_environment() and not local_install_override_enabled():
-    raise SystemExit(
-        'OhMyRunpod is intended to be installed only inside Runpod pods. '
-        f'If you are developing or testing locally, set {LOCAL_INSTALL_OVERRIDE}=1 to bypass this guard.'
-    )
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -35,6 +14,7 @@ setup(
     include_package_data=True,
     long_description=long_description,
     long_description_content_type='text/markdown',
+    license='GPL-3.0-only',
     install_requires=[
         'rich>=13.0.0',
     ],
@@ -50,7 +30,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
### Motivation
- Package builds and CI were failing because `setup.py` refused to run outside Runpod at import time, preventing `python -m build` and GitHub/CI from creating sdists/wheels. 
- Setuptools also emitted a deprecation warning for the license classifier, so the package metadata needed an SPDX expression.

### Description
- Remove the import-time Runpod environment guard from `setup.py` so build tools can create source/wheel distributions outside Runpod. 
- Add `license='GPL-3.0-only'` to `setup.py` and remove the deprecated license classifier line. 
- Update `README.md` to clarify that package builds and installations work outside Runpod while the runtime command still enforces the Runpod/runtime override. 
- No change to the runtime guard logic in `OhMyRunpod/environment.py`; the startup check for running the command outside Runpod remains unchanged.
