### PR TITLE
Remove Runpod-only install guard, add pyproject.toml, and update README/packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.md
 include LICENSE
-exclude CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OhMyRunpod is a comprehensive command-line tool designed to facilitate various o
 
 ## Installation
 
-OhMyRunpod is intended to be installed and run inside Runpod pods only. The package checks for Runpod-provided environment variables during installation and startup so users do not accidentally install it on a personal machine.
+OhMyRunpod is intended to run inside Runpod pods only. The command checks for Runpod-provided environment variables at startup so users do not accidentally run it on a personal machine, while package builds and CI can still create source and wheel distributions.
 
 To install OhMyRunpod on a Runpod pod, you can use pip:
 
@@ -25,10 +25,10 @@ To install OhMyRunpod on a Runpod pod, you can use pip:
 pip install OhMyRunpod
 ```
 
-For local development or CI outside Runpod, explicitly opt in to bypass the guard:
+For local development outside Runpod, installation and package builds work normally. Explicitly opt in only when you need to run the command locally:
 
 ```bash
-OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1 pip install -e .
+pip install -e .
 OHMYRUNPOD_ALLOW_LOCAL_INSTALL=1 OhMyRunpod --info
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,5 @@
 from setuptools import setup, find_packages
 import os
-import sys
-
-RUNPOD_ENV_VARS = (
-    'RUNPOD_POD_ID',
-    'RUNPOD_PUBLIC_IP',
-    'RUNPOD_TCP_PORT_22',
-    'RUNPOD_DC_ID',
-)
-LOCAL_INSTALL_OVERRIDE = 'OHMYRUNPOD_ALLOW_LOCAL_INSTALL'
-
-def is_runpod_environment():
-    return any(os.environ.get(var) for var in RUNPOD_ENV_VARS)
-
-def local_install_override_enabled():
-    return os.environ.get(LOCAL_INSTALL_OVERRIDE, '').lower() in {'1', 'true', 'yes', 'on'}
-
-if 'egg_info' not in sys.argv and not is_runpod_environment() and not local_install_override_enabled():
-    raise SystemExit(
-        'OhMyRunpod is intended to be installed only inside Runpod pods. '
-        f'If you are developing or testing locally, set {LOCAL_INSTALL_OVERRIDE}=1 to bypass this guard.'
-    )
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -35,6 +14,7 @@ setup(
     include_package_data=True,
     long_description=long_description,
     long_description_content_type='text/markdown',
+    license='GPL-3.0-only',
     install_requires=[
         'rich>=13.0.0',
     ],
@@ -50,7 +30,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
### Motivation

- Allow building and installing the package in non-Runpod environments and enable standard PEP 517/518 builds. 
- Clarify installation and runtime guidance in the `README.md` for local development and CI.

### Description

- Remove the install-time environment guard that exited installation when Runpod environment variables were not present, allowing normal installs outside Runpod. 
- Add a minimal `pyproject.toml` with a `setuptools` build backend to support modern packaging workflows. 
- Update `setup.py` to remove the guard and add the `license='GPL-3.0-only'` metadata while adjusting classifiers accordingly. 
- Update `README.md` to reword usage and local development instructions and adjust the example `OHMYRUNPOD_ALLOW_LOCAL_INSTALL` invocation. 