### PR TITLE
Fix Runpod guard without breaking package builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,17 @@ jobs:
       - name: Smoke test CLI help
         run: OhMyRunpod --help
 
+      - name: Smoke test local Runpod guard
+        shell: bash
+        run: |
+          if output="$(OhMyRunpod --info 2>&1)"; then
+            echo "OhMyRunpod unexpectedly ran outside Runpod"
+            exit 1
+          fi
+
+          echo "$output"
+          grep -Fq "intended to run only inside Runpod pods" <<< "$output"
+
       - name: Upload package distributions
         uses: actions/upload-artifact@v4
         with:

--- a/OhMyRunpod/environment.py
+++ b/OhMyRunpod/environment.py
@@ -28,7 +28,7 @@ def local_install_override_enabled(environ: Optional[Mapping[str, str]] = None) 
 
 
 def should_block_outside_runpod(environ: Optional[Mapping[str, str]] = None) -> bool:
-    """Return True when OhMyRunpod should refuse to run or install."""
+    """Return True when OhMyRunpod should refuse runtime execution."""
     return not is_runpod_environment(environ) and not local_install_override_enabled(environ)
 
 

--- a/OhMyRunpod/main.py
+++ b/OhMyRunpod/main.py
@@ -21,6 +21,7 @@ def load_runpod_modules():
 
     console = Console()
 
+
 def run_interactive_mode():
     """Run the interactive menu mode"""
     menu = InteractiveMenu()
@@ -69,6 +70,7 @@ def run_interactive_mode():
             console.print("\n[dim]Press any key to continue...[/dim]")
             input()
 
+
 def main():
     parser = argparse.ArgumentParser(description="OhMyRunpod Command Line Tool")
     parser.add_argument('--setup-ssh', action='store_true', help='Run the SSH setup script')
@@ -80,8 +82,7 @@ def main():
     args = parser.parse_args()
 
     if should_block_outside_runpod():
-        print(outside_runpod_message())
-        sys.exit(1)
+        parser.exit(1, outside_runpod_message() + "\n")
 
     load_runpod_modules()
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md'), encoding='utf-8'
 
 setup(
     name='OhMyRunpod',
-    version='0.6.4',
+    version='0.6.5',
     author='Madiator2011',
     author_email='admin@madiator.com',
     url='https://github.com/kodxana/OhMyRunpod-python',


### PR DESCRIPTION
## Summary

- keep the Runpod restriction as a runtime-only guard
- preserve `OhMyRunpod --help` outside Runpod
- add a GitHub Actions smoke test confirming local execution is blocked while package build/install succeeds
- bump the package version to `0.6.5`